### PR TITLE
Split APT key fetching operation to avoid issue with Ansible user agent

### DIFF
--- a/tasks/install/debian.yml
+++ b/tasks/install/debian.yml
@@ -1,8 +1,13 @@
 ---
 
 # RabbitMQ official install
+- name: "retrieve the official rabbitmq repository's key"
+  get_url:
+    url: http://www.rabbitmq.com/rabbitmq-release-signing-key.asc
+    dest: /tmp/rabbitmq-release-signing-key.asc
+
 - name: "add the official rabbitmq repository's key"
-  apt_key: url=http://www.rabbitmq.com/rabbitmq-release-signing-key.asc
+  apt_key: file=/tmp/rabbitmq-release-signing-key.asc
   when: not rabbitmq_os_package
 
 - name: add the official rabbitmq repository


### PR DESCRIPTION
Rabbitmq website does not allow anymore connection with a python user agent. Since apt-key module uses urllib with default user agent, this role is not able to fetch the APT key anymore.