### PR TITLE
Add user permissions option

### DIFF
--- a/tasks/vhost.yml
+++ b/tasks/vhost.yml
@@ -18,6 +18,7 @@
     vhost="{{ item.vhost | default('/', false) }}"
     node="{{ item.node | default('rabbit') }}"
     tags="{{ (item.tags | default('')) | join(',') }}"
+    permissions="{{ item.permissions | default([]) }}"
     configure_priv="{{ item.configure_priv | default('.*') }}"
     read_priv="{{ item.read_priv | default('.*') }}"
     write_priv="{{ item.write_priv | default('.*') }}"


### PR DESCRIPTION
Currently there was no way to specify multiple permissions for specific user, while ansible `rabbitmq_user` does support it. 